### PR TITLE
feat: implement ClaudeAPIClient and FallbackPlanProvider

### DIFF
--- a/FitnessTracker/App/AppEnvironment.swift
+++ b/FitnessTracker/App/AppEnvironment.swift
@@ -27,6 +27,8 @@ import SwiftData
 ///        ├─ ProgressRepository          (protocol → SwiftDataProgressRepository)
 ///        ├─ ExerciseLibraryService      (in-memory JSON cache)
 ///        ├─ KeychainService             (Security framework wrapper)
+///        ├─ ClaudeAPIClient             (Anthropic Messages API wrapper)
+///        ├─ FallbackPlanProvider        (offline workout-plan template)
 ///        ├─ HealthKitService            (HKHealthStore wrapper)
 ///        ├─ NotificationScheduler       (UNUserNotificationCenter wrapper)
 ///        └─ CloudSyncService            (CloudKit availability & sync-state monitor)
@@ -63,6 +65,12 @@ final class AppEnvironment {
     /// Wraps the iOS Keychain for secure storage of the Claude API key.
     let keychainService: KeychainService
 
+    /// HTTP client for the Anthropic Messages API; generates AI-powered workout plans.
+    let claudeAPIClient: ClaudeAPIClient
+
+    /// Offline fallback; returns a hard-coded template plan when the Claude API is unavailable.
+    let fallbackPlanProvider: FallbackPlanProvider
+
     /// Wraps `HKHealthStore` for HealthKit reads and workout writes.
     let healthKitService: any HealthKitServiceProtocol
 
@@ -84,6 +92,8 @@ final class AppEnvironment {
     ///   - progressRepository: Repository conforming to `ProgressRepository`.
     ///   - exerciseLibraryService: Service for exercise JSON management.
     ///   - keychainService: Service for Keychain access.
+    ///   - claudeAPIClient: HTTP client for Claude API workout-plan generation.
+    ///   - fallbackPlanProvider: Offline template plan provider.
     ///   - healthKitService: Service for HealthKit access.
     ///   - notificationScheduler: Service for scheduling workout-reminder notifications.
     ///   - cloudSyncService: Service for CloudKit sync monitoring and toggle.
@@ -95,6 +105,8 @@ final class AppEnvironment {
         progressRepository: any ProgressRepository,
         exerciseLibraryService: ExerciseLibraryService = ExerciseLibraryService(),
         keychainService: KeychainService = KeychainService(),
+        claudeAPIClient: ClaudeAPIClient? = nil,
+        fallbackPlanProvider: FallbackPlanProvider = FallbackPlanProvider(),
         healthKitService: any HealthKitServiceProtocol = HealthKitService.shared,
         notificationScheduler: any NotificationSchedulerProtocol = NotificationScheduler.shared,
         cloudSyncService: any CloudSyncServiceProtocol = CloudSyncService()
@@ -106,6 +118,9 @@ final class AppEnvironment {
         self.progressRepository = progressRepository
         self.exerciseLibraryService = exerciseLibraryService
         self.keychainService = keychainService
+        // Build a ClaudeAPIClient backed by the provided KeychainService if none was injected.
+        self.claudeAPIClient = claudeAPIClient ?? ClaudeAPIClient(keychainService: keychainService)
+        self.fallbackPlanProvider = fallbackPlanProvider
         self.healthKitService = healthKitService
         self.notificationScheduler = notificationScheduler
         self.cloudSyncService = cloudSyncService

--- a/FitnessTracker/Services/ClaudeAPIClient.swift
+++ b/FitnessTracker/Services/ClaudeAPIClient.swift
@@ -1,0 +1,352 @@
+import Foundation
+
+// MARK: - WorkoutPlanGenerating
+
+/// Protocol shared by `ClaudeAPIClient` (live) and `FallbackPlanProvider` (offline/test).
+///
+/// Conforming types accept a `UserProfile` and return a fully-populated
+/// `WorkoutPlan` entity graph that the caller can insert into a SwiftData context.
+protocol WorkoutPlanGenerating {
+    func generatePlan(profile: UserProfile) async throws -> WorkoutPlan
+}
+
+// MARK: - WorkoutPlanResponse DTOs
+
+/// Top-level JSON response returned by the Claude API for workout plan generation.
+struct WorkoutPlanResponse: Decodable {
+    let splitType: String
+    let days: [DayResponse]
+
+    struct DayResponse: Decodable {
+        let label: String
+        /// ISO weekday index (1 = Sunday … 7 = Saturday). Optional so the client
+        /// can supply a default when Claude omits it.
+        let weekdayIndex: Int?
+        let exercises: [ExerciseResponse]
+    }
+
+    struct ExerciseResponse: Decodable {
+        let name: String
+        let sets: Int
+        /// Rep range string, e.g. `"6-8"` or `"12"`.
+        let reps: String
+        let restSeconds: Int?
+    }
+}
+
+// MARK: - ClaudeMessagesResponse
+
+/// Envelope returned by the Anthropic Messages API (`/v1/messages`).
+private struct ClaudeMessagesResponse: Decodable {
+    struct Content: Decodable {
+        let type: String
+        let text: String?
+    }
+    let content: [Content]
+}
+
+// MARK: - ClaudeAPIError
+
+/// Typed errors thrown by `ClaudeAPIClient`.
+enum ClaudeAPIError: LocalizedError {
+    case missingAPIKey
+    case invalidURL
+    case networkFailure(Error)
+    case httpError(statusCode: Int)
+    case decodingFailure(Error)
+
+    var errorDescription: String? {
+        switch self {
+        case .missingAPIKey:
+            return "Claude API key is not configured. Please add your API key in Settings."
+        case .invalidURL:
+            return "The Claude API endpoint URL is invalid."
+        case .networkFailure(let underlying):
+            return "Network request failed: \(underlying.localizedDescription)"
+        case .httpError(let code):
+            return "Claude API returned HTTP \(code)."
+        case .decodingFailure(let underlying):
+            return "Failed to decode workout plan response: \(underlying.localizedDescription)"
+        }
+    }
+}
+
+// MARK: - ClaudeAPIClient
+
+/// Thin `async/await` HTTP client for the Anthropic Messages API.
+///
+/// Constructs a structured prompt from a `UserProfile` (deriving experience level,
+/// recommended days per week, and a default equipment list), POSTs to
+/// `https://api.anthropic.com/v1/messages`, strips any markdown fences from the
+/// response, and maps the decoded `WorkoutPlanResponse` into a SwiftData
+/// `WorkoutPlan` entity graph.
+///
+/// The Claude API key is retrieved at call time from the iOS Keychain via
+/// `KeychainService`. If the key is absent, or if the network call fails,
+/// the caller should catch `ClaudeAPIError` and fall back to `FallbackPlanProvider`.
+///
+/// Example usage:
+/// ```swift
+/// let client = ClaudeAPIClient(keychainService: env.keychainService)
+/// let plan = try await client.generatePlan(profile: userProfile)
+/// ```
+final class ClaudeAPIClient: WorkoutPlanGenerating {
+
+    // MARK: - Constants
+
+    private enum Constants {
+        static let apiURLString = "https://api.anthropic.com/v1/messages"
+        static let model = "claude-opus-4-6"
+        static let maxTokens = 1024
+        static let anthropicVersion = "2023-06-01"
+    }
+
+    // MARK: - Dependencies
+
+    private let keychainService: KeychainService
+    private let session: URLSession
+
+    // MARK: - Init
+
+    /// - Parameters:
+    ///   - keychainService: Provides the Claude API key stored in the Keychain.
+    ///   - session: URL session to use for network requests. Defaults to `.shared`.
+    ///              Inject a custom session in tests to avoid real network calls.
+    init(keychainService: KeychainService, session: URLSession = .shared) {
+        self.keychainService = keychainService
+        self.session = session
+    }
+
+    // MARK: - WorkoutPlanGenerating
+
+    /// Generates a `WorkoutPlan` by calling the Claude Messages API.
+    ///
+    /// The returned plan is detached (not yet inserted into a `ModelContext`).
+    /// Insert it and any related `WorkoutDay` / `PlannedExercise` entities via your
+    /// repository after this call succeeds.
+    ///
+    /// - Parameter profile: The user's profile, used to derive goal, experience
+    ///   level, and recommended training days per week.
+    /// - Returns: A populated `WorkoutPlan` entity graph.
+    /// - Throws: `ClaudeAPIError` on missing key, network failure, non-200 HTTP
+    ///   status, or JSON decoding failure.
+    func generatePlan(profile: UserProfile) async throws -> WorkoutPlan {
+        let apiKey = try retrieveAPIKey()
+
+        guard let url = URL(string: Constants.apiURLString) else {
+            throw ClaudeAPIError.invalidURL
+        }
+
+        var urlRequest = URLRequest(url: url)
+        urlRequest.httpMethod = "POST"
+        urlRequest.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        urlRequest.setValue(apiKey, forHTTPHeaderField: "x-api-key")
+        urlRequest.setValue(Constants.anthropicVersion, forHTTPHeaderField: "anthropic-version")
+        urlRequest.httpBody = try JSONEncoder().encode(makeRequestBody(for: profile))
+
+        let (data, response) = try await performRequest(urlRequest)
+
+        if let http = response as? HTTPURLResponse, http.statusCode != 200 {
+            throw ClaudeAPIError.httpError(statusCode: http.statusCode)
+        }
+
+        let planResponse = try decodeWorkoutPlanResponse(from: data)
+        return mapToWorkoutPlan(planResponse: planResponse, profile: profile)
+    }
+
+    // MARK: - Private — network
+
+    private func retrieveAPIKey() throws -> String {
+        guard let key = try keychainService.apiKey(), !key.isEmpty else {
+            throw ClaudeAPIError.missingAPIKey
+        }
+        return key
+    }
+
+    private func performRequest(_ request: URLRequest) async throws -> (Data, URLResponse) {
+        do {
+            return try await session.data(for: request)
+        } catch {
+            throw ClaudeAPIError.networkFailure(error)
+        }
+    }
+
+    // MARK: - Private — decoding
+
+    private func decodeWorkoutPlanResponse(from data: Data) throws -> WorkoutPlanResponse {
+        let claudeResponse: ClaudeMessagesResponse
+        do {
+            claudeResponse = try JSONDecoder().decode(ClaudeMessagesResponse.self, from: data)
+        } catch {
+            throw ClaudeAPIError.decodingFailure(error)
+        }
+
+        guard let text = claudeResponse.content.first(where: { $0.type == "text" })?.text else {
+            throw ClaudeAPIError.decodingFailure(
+                NSError(
+                    domain: "ClaudeAPIClient",
+                    code: -1,
+                    userInfo: [NSLocalizedDescriptionKey: "No text content found in Claude response"]
+                )
+            )
+        }
+
+        let jsonText = stripMarkdownFences(from: text)
+
+        guard let jsonData = jsonText.data(using: .utf8) else {
+            throw ClaudeAPIError.decodingFailure(
+                NSError(
+                    domain: "ClaudeAPIClient",
+                    code: -2,
+                    userInfo: [NSLocalizedDescriptionKey: "Could not re-encode trimmed response text as UTF-8"]
+                )
+            )
+        }
+
+        do {
+            return try JSONDecoder().decode(WorkoutPlanResponse.self, from: jsonData)
+        } catch {
+            throw ClaudeAPIError.decodingFailure(error)
+        }
+    }
+
+    /// Removes leading ` ```json ` / ` ``` ` fences and trailing ` ``` ` fences that
+    /// Claude sometimes wraps its JSON output in, then trims whitespace.
+    private func stripMarkdownFences(from text: String) -> String {
+        var result = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        if result.hasPrefix("```json") {
+            result = String(result.dropFirst("```json".count))
+        } else if result.hasPrefix("```") {
+            result = String(result.dropFirst(3))
+        }
+        if result.hasSuffix("```") {
+            result = String(result.dropLast(3))
+        }
+        return result.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    // MARK: - Private — mapping
+
+    /// Maps a decoded `WorkoutPlanResponse` into a SwiftData entity graph.
+    ///
+    /// `PlannedExercise.exercise` is left `nil`; callers may resolve exercise
+    /// references by name via `ExerciseLibraryService` before persisting.
+    private func mapToWorkoutPlan(planResponse: WorkoutPlanResponse, profile: UserProfile) -> WorkoutPlan {
+        let splitType = SplitType(rawValue: planResponse.splitType) ?? .fullBody
+        let plan = WorkoutPlan(
+            splitType: splitType,
+            daysPerWeek: planResponse.days.count,
+            userProfile: profile
+        )
+
+        for (index, dayResponse) in planResponse.days.enumerated() {
+            // Default to consecutive weekdays starting Monday (weekdayIndex 2)
+            // when the API omits the field.
+            let weekdayIndex = dayResponse.weekdayIndex ?? ((index % 7) + 2)
+            let day = WorkoutDay(
+                dayLabel: dayResponse.label,
+                weekdayIndex: weekdayIndex,
+                workoutPlan: plan
+            )
+            plan.days.append(day)
+
+            for (sortOrder, exerciseResponse) in dayResponse.exercises.enumerated() {
+                let planned = PlannedExercise(
+                    targetSets: exerciseResponse.sets,
+                    targetReps: exerciseResponse.reps,
+                    sortOrder: sortOrder,
+                    workoutDay: day
+                )
+                day.plannedExercises.append(planned)
+            }
+        }
+
+        return plan
+    }
+
+    // MARK: - Private — request body
+
+    private struct RequestBody: Encodable {
+        let model: String
+        let maxTokens: Int
+        let system: String
+        let messages: [Message]
+
+        enum CodingKeys: String, CodingKey {
+            case model
+            case maxTokens = "max_tokens"
+            case system
+            case messages
+        }
+
+        struct Message: Encodable {
+            let role: String
+            let content: String
+        }
+    }
+
+    /// Builds the Claude API request body, embedding the four user-profile inputs
+    /// (goal, experience level, equipment list, days per week) into a structured prompt.
+    private func makeRequestBody(for profile: UserProfile) -> RequestBody {
+        let goal = profile.goal.rawValue
+        let experience = experienceLabel(for: profile.activityLevel)
+        let daysPerWeek = recommendedDays(for: profile.activityLevel)
+        let equipment = defaultEquipment()
+
+        let userContent = """
+        Generate a workout plan for the following profile:
+        - Goal: \(goal)
+        - Experience level: \(experience)
+        - Available equipment: \(equipment.joined(separator: ", "))
+        - Training days per week: \(daysPerWeek)
+
+        Return ONLY valid JSON matching this exact schema (no markdown, no extra text):
+        {
+          "splitType": "<PPL|FullBody|UpperLower>",
+          "days": [
+            {
+              "label": "<day label, e.g. Push A>",
+              "weekdayIndex": <1-7>,
+              "exercises": [
+                { "name": "<exercise name>", "sets": <int>, "reps": "<e.g. 6-8>", "restSeconds": <int> }
+              ]
+            }
+          ]
+        }
+        """
+
+        return RequestBody(
+            model: Constants.model,
+            maxTokens: Constants.maxTokens,
+            system: "You are a certified personal trainer. Return ONLY valid JSON matching the schema provided. Do not include markdown fences, explanations, or any text outside the JSON object.",
+            messages: [.init(role: "user", content: userContent)]
+        )
+    }
+
+    // MARK: - Private — profile-to-prompt helpers
+
+    /// Maps `ActivityLevel` to a human-readable experience label for the prompt.
+    private func experienceLabel(for level: ActivityLevel) -> String {
+        switch level {
+        case .sedentary, .lightlyActive:   return "beginner"
+        case .moderatelyActive:            return "intermediate"
+        case .veryActive, .extraActive:    return "advanced"
+        }
+    }
+
+    /// Derives a recommended training frequency from `ActivityLevel`.
+    private func recommendedDays(for level: ActivityLevel) -> Int {
+        switch level {
+        case .sedentary:        return 3
+        case .lightlyActive:    return 3
+        case .moderatelyActive: return 4
+        case .veryActive:       return 5
+        case .extraActive:      return 6
+        }
+    }
+
+    /// Standard equipment list used in every generated plan.
+    private func defaultEquipment() -> [String] {
+        ["Barbell", "Dumbbell", "Cable", "Machine", "Bodyweight"]
+    }
+}

--- a/FitnessTracker/Services/FallbackPlanProvider.swift
+++ b/FitnessTracker/Services/FallbackPlanProvider.swift
@@ -1,0 +1,102 @@
+import Foundation
+
+// MARK: - FallbackPlanProvider
+
+/// Returns a hard-coded template `WorkoutPlan` when the Claude API is unavailable.
+///
+/// The fallback plan is a 3-day full-body programme containing sensible defaults
+/// for any experience level. It satisfies the `WorkoutPlanGenerating` protocol so
+/// `WorkoutPlanViewModel` can call it identically to `ClaudeAPIClient` and fall
+/// back transparently on any `ClaudeAPIError`.
+///
+/// The returned entities are detached (not yet inserted into a `ModelContext`).
+/// `PlannedExercise.exercise` is left `nil`; callers may resolve exercise
+/// references by name via `ExerciseLibraryService` before persisting.
+///
+/// No network call is made. The function is non-throwing; `async throws` is
+/// declared only to satisfy the `WorkoutPlanGenerating` protocol.
+final class FallbackPlanProvider: WorkoutPlanGenerating {
+
+    // MARK: - WorkoutPlanGenerating
+
+    func generatePlan(profile: UserProfile) async throws -> WorkoutPlan {
+        makeFullBodyPlan(profile: profile)
+    }
+
+    // MARK: - Template plan
+
+    private func makeFullBodyPlan(profile: UserProfile) -> WorkoutPlan {
+        let plan = WorkoutPlan(
+            splitType: .fullBody,
+            daysPerWeek: 3,
+            userProfile: profile
+        )
+
+        // Spread across Monday (2), Wednesday (4), Friday (6).
+        let dayA = makeDay(
+            label: "Full Body A",
+            weekdayIndex: 2,
+            plan: plan,
+            exercises: [
+                (name: "Barbell Squat",        sets: 4, reps: "5"),
+                (name: "Barbell Bench Press",  sets: 4, reps: "6-8"),
+                (name: "Barbell Row",          sets: 4, reps: "6-8"),
+                (name: "Overhead Press",       sets: 3, reps: "8-10"),
+                (name: "Romanian Deadlift",    sets: 3, reps: "10"),
+            ]
+        )
+
+        let dayB = makeDay(
+            label: "Full Body B",
+            weekdayIndex: 4,
+            plan: plan,
+            exercises: [
+                (name: "Deadlift",                 sets: 4, reps: "5"),
+                (name: "Incline Dumbbell Press",   sets: 4, reps: "8-10"),
+                (name: "Pull-Up",                  sets: 4, reps: "6-8"),
+                (name: "Dumbbell Lateral Raise",   sets: 3, reps: "12-15"),
+                (name: "Leg Press",                sets: 3, reps: "10-12"),
+            ]
+        )
+
+        let dayC = makeDay(
+            label: "Full Body C",
+            weekdayIndex: 6,
+            plan: plan,
+            exercises: [
+                (name: "Front Squat",              sets: 4, reps: "6-8"),
+                (name: "Dumbbell Bench Press",     sets: 3, reps: "10-12"),
+                (name: "Seated Cable Row",         sets: 3, reps: "10-12"),
+                (name: "Dumbbell Shoulder Press",  sets: 3, reps: "10-12"),
+                (name: "Nordic Hamstring Curl",    sets: 3, reps: "8"),
+            ]
+        )
+
+        plan.days = [dayA, dayB, dayC]
+        return plan
+    }
+
+    // MARK: - Private helpers
+
+    private func makeDay(
+        label: String,
+        weekdayIndex: Int,
+        plan: WorkoutPlan,
+        exercises: [(name: String, sets: Int, reps: String)]
+    ) -> WorkoutDay {
+        let day = WorkoutDay(
+            dayLabel: label,
+            weekdayIndex: weekdayIndex,
+            workoutPlan: plan
+        )
+        day.plannedExercises = exercises.enumerated().map { index, ex in
+            PlannedExercise(
+                targetSets: ex.sets,
+                targetReps: ex.reps,
+                sortOrder: index,
+                workoutDay: day
+            )
+        }
+        return day
+    }
+}

--- a/FitnessTrackerTests/ClaudeAPIClientTests.swift
+++ b/FitnessTrackerTests/ClaudeAPIClientTests.swift
@@ -1,0 +1,457 @@
+import XCTest
+import SwiftData
+@testable import FitnessTracker
+
+// MARK: - MockURLProtocol
+
+/// Intercepts URL requests in tests and returns pre-configured responses.
+/// Register a `requestHandler` before each test that uses this protocol.
+final class MockURLProtocol: URLProtocol, @unchecked Sendable {
+
+    /// Set this to provide the (HTTPURLResponse, Data) the mock returns, or throw
+    /// to simulate a network-level failure.
+    static var requestHandler: ((URLRequest) throws -> (HTTPURLResponse, Data))?
+
+    override class func canInit(with request: URLRequest) -> Bool { true }
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+
+    override func startLoading() {
+        guard let handler = MockURLProtocol.requestHandler else {
+            client?.urlProtocol(self, didFailWithError: URLError(.unknown))
+            return
+        }
+        do {
+            let (response, data) = try handler(request)
+            client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+            client?.urlProtocol(self, didLoad: data)
+            client?.urlProtocolDidFinishLoading(self)
+        } catch {
+            client?.urlProtocol(self, didFailWithError: error)
+        }
+    }
+
+    override func stopLoading() {}
+}
+
+// MARK: - ClaudeAPIClientTests
+
+@MainActor
+final class ClaudeAPIClientTests: XCTestCase {
+
+    // MARK: - Properties
+
+    private var mockSession: URLSession!
+    private var keychainService: KeychainService!
+    private let testKeychainService = "com.fitnessTracker.tests.claude"
+    private var sut: ClaudeAPIClient!
+
+    // MARK: - Setup / Teardown
+
+    override func setUp() {
+        super.setUp()
+
+        // Configure URLSession to use MockURLProtocol for all requests.
+        let config = URLSessionConfiguration.ephemeral
+        config.protocolClasses = [MockURLProtocol.self]
+        mockSession = URLSession(configuration: config)
+
+        keychainService = KeychainService(service: testKeychainService)
+        // Pre-populate a test API key so tests don't fail with missingAPIKey.
+        try? keychainService.saveAPIKey("sk-ant-test-key")
+
+        sut = ClaudeAPIClient(keychainService: keychainService, session: mockSession)
+    }
+
+    override func tearDown() {
+        MockURLProtocol.requestHandler = nil
+        try? keychainService.deleteAPIKey()
+        sut = nil
+        mockSession = nil
+        keychainService = nil
+        super.tearDown()
+    }
+
+    // MARK: - Helpers
+
+    private func makeProfile(
+        goal: FitnessGoal = .bulk,
+        activityLevel: ActivityLevel = .moderatelyActive
+    ) throws -> UserProfile {
+        let container = try AppSchema.makeContainer(inMemory: true)
+        return UserProfile(
+            name: "Test User",
+            age: 28,
+            gender: .male,
+            heightCm: 180,
+            weightKg: 80,
+            activityLevel: activityLevel,
+            goal: goal,
+            tdeeKcal: 2800,
+            proteinTargetG: 200,
+            carbTargetG: 300,
+            fatTargetG: 80
+        )
+    }
+
+    /// Builds a valid Claude API JSON response for the given plan JSON string.
+    private func makeClaudeEnvelope(planJSON: String) -> Data {
+        let escaped = planJSON
+            .replacingOccurrences(of: "\\", with: "\\\\")
+            .replacingOccurrences(of: "\"", with: "\\\"")
+            .replacingOccurrences(of: "\n", with: "\\n")
+        let envelope = """
+        {
+          "content": [
+            { "type": "text", "text": "\(escaped)" }
+          ]
+        }
+        """
+        return Data(envelope.utf8)
+    }
+
+    private func makeHTTPResponse(statusCode: Int = 200) -> HTTPURLResponse {
+        HTTPURLResponse(
+            url: URL(string: "https://api.anthropic.com/v1/messages")!,
+            statusCode: statusCode,
+            httpVersion: nil,
+            headerFields: nil
+        )!
+    }
+
+    /// A minimal valid `WorkoutPlanResponse` JSON.
+    private var validPlanJSON: String {
+        """
+        {
+          "splitType": "FullBody",
+          "days": [
+            {
+              "label": "Full Body A",
+              "weekdayIndex": 2,
+              "exercises": [
+                { "name": "Barbell Squat", "sets": 4, "reps": "5", "restSeconds": 180 },
+                { "name": "Bench Press", "sets": 4, "reps": "6-8", "restSeconds": 120 }
+              ]
+            }
+          ]
+        }
+        """
+    }
+
+    // MARK: - Success path
+
+    func test_generatePlan_validResponse_returnsPopulatedWorkoutPlan() async throws {
+        let profile = try makeProfile()
+        let responseData = makeClaudeEnvelope(planJSON: validPlanJSON)
+
+        MockURLProtocol.requestHandler = { [weak self] _ in
+            (self!.makeHTTPResponse(), responseData)
+        }
+
+        let plan = try await sut.generatePlan(profile: profile)
+
+        XCTAssertEqual(plan.splitType, .fullBody)
+        XCTAssertEqual(plan.daysPerWeek, 1)
+        XCTAssertFalse(plan.days.isEmpty)
+        XCTAssertEqual(plan.days.first?.dayLabel, "Full Body A")
+        XCTAssertEqual(plan.days.first?.weekdayIndex, 2)
+        XCTAssertEqual(plan.days.first?.plannedExercises.count, 2)
+    }
+
+    func test_generatePlan_setsAndRepsAreMapped() async throws {
+        let profile = try makeProfile()
+        let responseData = makeClaudeEnvelope(planJSON: validPlanJSON)
+
+        MockURLProtocol.requestHandler = { [weak self] _ in
+            (self!.makeHTTPResponse(), responseData)
+        }
+
+        let plan = try await sut.generatePlan(profile: profile)
+        let first = plan.days.first?.plannedExercises.first
+
+        XCTAssertEqual(first?.targetSets, 4)
+        XCTAssertEqual(first?.targetReps, "5")
+        XCTAssertEqual(first?.sortOrder, 0)
+    }
+
+    func test_generatePlan_unknownSplitType_defaultsToFullBody() async throws {
+        let profile = try makeProfile()
+        let json = """
+        {
+          "splitType": "UnknownSplit",
+          "days": [
+            {
+              "label": "Day 1",
+              "weekdayIndex": 2,
+              "exercises": [
+                { "name": "Push-Up", "sets": 3, "reps": "15", "restSeconds": 60 }
+              ]
+            }
+          ]
+        }
+        """
+        let responseData = makeClaudeEnvelope(planJSON: json)
+        MockURLProtocol.requestHandler = { [weak self] _ in
+            (self!.makeHTTPResponse(), responseData)
+        }
+
+        let plan = try await sut.generatePlan(profile: profile)
+        XCTAssertEqual(plan.splitType, .fullBody)
+    }
+
+    func test_generatePlan_stripsMarkdownFences() async throws {
+        let profile = try makeProfile()
+        let fencedJSON = "```json\n\(validPlanJSON)\n```"
+        let responseData = makeClaudeEnvelope(planJSON: fencedJSON)
+
+        MockURLProtocol.requestHandler = { [weak self] _ in
+            (self!.makeHTTPResponse(), responseData)
+        }
+
+        // Should not throw — fences must be stripped before JSON decode.
+        let plan = try await sut.generatePlan(profile: profile)
+        XCTAssertFalse(plan.days.isEmpty)
+    }
+
+    func test_generatePlan_stripsBareMarkdownFences() async throws {
+        let profile = try makeProfile()
+        let fencedJSON = "```\n\(validPlanJSON)\n```"
+        let responseData = makeClaudeEnvelope(planJSON: fencedJSON)
+
+        MockURLProtocol.requestHandler = { [weak self] _ in
+            (self!.makeHTTPResponse(), responseData)
+        }
+
+        let plan = try await sut.generatePlan(profile: profile)
+        XCTAssertFalse(plan.days.isEmpty)
+    }
+
+    // MARK: - Error paths
+
+    func test_generatePlan_missingAPIKey_throwsMissingAPIKey() async throws {
+        try keychainService.deleteAPIKey()
+        let profile = try makeProfile()
+
+        do {
+            _ = try await sut.generatePlan(profile: profile)
+            XCTFail("Expected ClaudeAPIError.missingAPIKey")
+        } catch ClaudeAPIError.missingAPIKey {
+            // Expected
+        }
+    }
+
+    func test_generatePlan_networkFailure_throwsNetworkFailure() async throws {
+        let profile = try makeProfile()
+        MockURLProtocol.requestHandler = { _ in
+            throw URLError(.notConnectedToInternet)
+        }
+
+        do {
+            _ = try await sut.generatePlan(profile: profile)
+            XCTFail("Expected ClaudeAPIError.networkFailure")
+        } catch ClaudeAPIError.networkFailure {
+            // Expected
+        }
+    }
+
+    func test_generatePlan_non200StatusCode_throwsHTTPError() async throws {
+        let profile = try makeProfile()
+        MockURLProtocol.requestHandler = { [weak self] _ in
+            (self!.makeHTTPResponse(statusCode: 401), Data())
+        }
+
+        do {
+            _ = try await sut.generatePlan(profile: profile)
+            XCTFail("Expected ClaudeAPIError.httpError")
+        } catch ClaudeAPIError.httpError(let code) {
+            XCTAssertEqual(code, 401)
+        }
+    }
+
+    func test_generatePlan_500StatusCode_throwsHTTPError() async throws {
+        let profile = try makeProfile()
+        MockURLProtocol.requestHandler = { [weak self] _ in
+            (self!.makeHTTPResponse(statusCode: 500), Data())
+        }
+
+        do {
+            _ = try await sut.generatePlan(profile: profile)
+            XCTFail("Expected ClaudeAPIError.httpError")
+        } catch ClaudeAPIError.httpError(let code) {
+            XCTAssertEqual(code, 500)
+        }
+    }
+
+    func test_generatePlan_malformedJSON_throwsDecodingFailure() async throws {
+        let profile = try makeProfile()
+        // Return a Claude envelope, but with invalid inner JSON.
+        let badInner = "this is not json at all"
+        let responseData = makeClaudeEnvelope(planJSON: badInner)
+        MockURLProtocol.requestHandler = { [weak self] _ in
+            (self!.makeHTTPResponse(), responseData)
+        }
+
+        do {
+            _ = try await sut.generatePlan(profile: profile)
+            XCTFail("Expected ClaudeAPIError.decodingFailure")
+        } catch ClaudeAPIError.decodingFailure {
+            // Expected
+        }
+    }
+
+    func test_generatePlan_invalidClaudeEnvelope_throwsDecodingFailure() async throws {
+        let profile = try makeProfile()
+        // Raw bytes that are not valid JSON at all.
+        let garbage = Data("not-json".utf8)
+        MockURLProtocol.requestHandler = { [weak self] _ in
+            (self!.makeHTTPResponse(), garbage)
+        }
+
+        do {
+            _ = try await sut.generatePlan(profile: profile)
+            XCTFail("Expected ClaudeAPIError.decodingFailure")
+        } catch ClaudeAPIError.decodingFailure {
+            // Expected
+        }
+    }
+
+    // MARK: - Prompt content
+
+    func test_generatePlan_requestContainsAllFourInputFields() async throws {
+        let profile = try makeProfile(goal: .cut, activityLevel: .veryActive)
+
+        var capturedRequest: URLRequest?
+        MockURLProtocol.requestHandler = { [weak self] request in
+            capturedRequest = request
+            return (self!.makeHTTPResponse(), self!.makeClaudeEnvelope(planJSON: self!.validPlanJSON))
+        }
+
+        _ = try? await sut.generatePlan(profile: profile)
+
+        guard let body = capturedRequest?.httpBody,
+              let bodyString = String(data: body, encoding: .utf8) else {
+            XCTFail("Request body was empty or not UTF-8")
+            return
+        }
+
+        // Verify the four required input fields appear in the prompt.
+        XCTAssertTrue(bodyString.contains("Goal"), "Prompt must include goal field")
+        XCTAssertTrue(bodyString.contains("Experience level"), "Prompt must include experience level field")
+        XCTAssertTrue(bodyString.contains("equipment"), "Prompt must include equipment field")
+        XCTAssertTrue(bodyString.contains("days per week"), "Prompt must include days per week field")
+    }
+
+    func test_generatePlan_requestUsesCorrectModel() async throws {
+        let profile = try makeProfile()
+        var capturedRequest: URLRequest?
+
+        MockURLProtocol.requestHandler = { [weak self] request in
+            capturedRequest = request
+            return (self!.makeHTTPResponse(), self!.makeClaudeEnvelope(planJSON: self!.validPlanJSON))
+        }
+
+        _ = try? await sut.generatePlan(profile: profile)
+
+        guard let body = capturedRequest?.httpBody,
+              let bodyString = String(data: body, encoding: .utf8) else {
+            XCTFail("Request body was empty")
+            return
+        }
+
+        XCTAssertTrue(bodyString.contains("claude-opus-4-6"), "Request must use claude-opus-4-6 model")
+    }
+
+    func test_generatePlan_requestSetsRequiredHeaders() async throws {
+        let profile = try makeProfile()
+        var capturedRequest: URLRequest?
+
+        MockURLProtocol.requestHandler = { [weak self] request in
+            capturedRequest = request
+            return (self!.makeHTTPResponse(), self!.makeClaudeEnvelope(planJSON: self!.validPlanJSON))
+        }
+
+        _ = try? await sut.generatePlan(profile: profile)
+
+        XCTAssertEqual(capturedRequest?.value(forHTTPHeaderField: "Content-Type"), "application/json")
+        XCTAssertNotNil(capturedRequest?.value(forHTTPHeaderField: "x-api-key"))
+        XCTAssertNotNil(capturedRequest?.value(forHTTPHeaderField: "anthropic-version"))
+    }
+
+    // MARK: - Goal mapping in prompt
+
+    func test_generatePlan_cutGoal_includesGoalInPrompt() async throws {
+        let profile = try makeProfile(goal: .cut)
+        var capturedRequest: URLRequest?
+
+        MockURLProtocol.requestHandler = { [weak self] request in
+            capturedRequest = request
+            return (self!.makeHTTPResponse(), self!.makeClaudeEnvelope(planJSON: self!.validPlanJSON))
+        }
+
+        _ = try? await sut.generatePlan(profile: profile)
+
+        let body = capturedRequest.flatMap { $0.httpBody }
+            .flatMap { String(data: $0, encoding: .utf8) } ?? ""
+
+        XCTAssertTrue(body.contains("cut"), "Prompt must include the user's goal value")
+    }
+
+    // MARK: - Multi-day plan mapping
+
+    func test_generatePlan_multipleDays_mapsSortOrderCorrectly() async throws {
+        let profile = try makeProfile()
+        let multiDayJSON = """
+        {
+          "splitType": "PPL",
+          "days": [
+            {
+              "label": "Push",
+              "weekdayIndex": 2,
+              "exercises": [
+                { "name": "Bench Press", "sets": 4, "reps": "6-8", "restSeconds": 120 },
+                { "name": "Overhead Press", "sets": 3, "reps": "8-10", "restSeconds": 90 },
+                { "name": "Lateral Raise", "sets": 3, "reps": "12-15", "restSeconds": 60 }
+              ]
+            }
+          ]
+        }
+        """
+
+        MockURLProtocol.requestHandler = { [weak self] _ in
+            (self!.makeHTTPResponse(), self!.makeClaudeEnvelope(planJSON: multiDayJSON))
+        }
+
+        let plan = try await sut.generatePlan(profile: profile)
+        let exercises = plan.days.first?.plannedExercises.sorted { $0.sortOrder < $1.sortOrder } ?? []
+
+        XCTAssertEqual(exercises.count, 3)
+        XCTAssertEqual(exercises[0].sortOrder, 0)
+        XCTAssertEqual(exercises[1].sortOrder, 1)
+        XCTAssertEqual(exercises[2].sortOrder, 2)
+    }
+
+    func test_generatePlan_weekdayIndexAbsent_assignsDefault() async throws {
+        let profile = try makeProfile()
+        let noIndexJSON = """
+        {
+          "splitType": "FullBody",
+          "days": [
+            {
+              "label": "Day 1",
+              "exercises": [
+                { "name": "Squat", "sets": 3, "reps": "8", "restSeconds": 90 }
+              ]
+            }
+          ]
+        }
+        """
+
+        MockURLProtocol.requestHandler = { [weak self] _ in
+            (self!.makeHTTPResponse(), self!.makeClaudeEnvelope(planJSON: noIndexJSON))
+        }
+
+        let plan = try await sut.generatePlan(profile: profile)
+        let weekdayIndex = plan.days.first?.weekdayIndex ?? 0
+        // Default for first day (index 0): (0 % 7) + 2 = 2
+        XCTAssertEqual(weekdayIndex, 2)
+    }
+}

--- a/FitnessTrackerTests/FallbackPlanProviderTests.swift
+++ b/FitnessTrackerTests/FallbackPlanProviderTests.swift
@@ -1,0 +1,175 @@
+import XCTest
+import SwiftData
+@testable import FitnessTracker
+
+// MARK: - FallbackPlanProviderTests
+
+@MainActor
+final class FallbackPlanProviderTests: XCTestCase {
+
+    // MARK: - Properties
+
+    private var sut: FallbackPlanProvider!
+
+    // MARK: - Setup / Teardown
+
+    override func setUp() {
+        super.setUp()
+        sut = FallbackPlanProvider()
+    }
+
+    override func tearDown() {
+        sut = nil
+        super.tearDown()
+    }
+
+    // MARK: - Helpers
+
+    private func makeProfile(
+        goal: FitnessGoal = .maintain,
+        activityLevel: ActivityLevel = .moderatelyActive
+    ) throws -> UserProfile {
+        let container = try AppSchema.makeContainer(inMemory: true)
+        _ = container // keep alive
+        return UserProfile(
+            name: "Fallback Test User",
+            age: 30,
+            gender: .female,
+            heightCm: 165,
+            weightKg: 65,
+            activityLevel: activityLevel,
+            goal: goal,
+            tdeeKcal: 2200,
+            proteinTargetG: 150,
+            carbTargetG: 230,
+            fatTargetG: 65
+        )
+    }
+
+    // MARK: - Non-empty plan
+
+    func test_generatePlan_returnsNonEmptyWorkoutPlan() async throws {
+        let profile = try makeProfile()
+        let plan = try await sut.generatePlan(profile: profile)
+        XCTAssertFalse(plan.days.isEmpty, "Fallback plan must have at least one workout day")
+    }
+
+    func test_generatePlan_planHasExpectedDayCount() async throws {
+        let profile = try makeProfile()
+        let plan = try await sut.generatePlan(profile: profile)
+        XCTAssertEqual(plan.daysPerWeek, 3)
+        XCTAssertEqual(plan.days.count, 3)
+    }
+
+    func test_generatePlan_isFullBodySplit() async throws {
+        let profile = try makeProfile()
+        let plan = try await sut.generatePlan(profile: profile)
+        XCTAssertEqual(plan.splitType, .fullBody)
+    }
+
+    // MARK: - Days structure
+
+    func test_generatePlan_eachDayHasExercises() async throws {
+        let profile = try makeProfile()
+        let plan = try await sut.generatePlan(profile: profile)
+
+        for day in plan.days {
+            XCTAssertFalse(
+                day.plannedExercises.isEmpty,
+                "Day '\(day.dayLabel)' must have at least one planned exercise"
+            )
+        }
+    }
+
+    func test_generatePlan_dayLabelsAreNonEmpty() async throws {
+        let profile = try makeProfile()
+        let plan = try await sut.generatePlan(profile: profile)
+
+        for day in plan.days {
+            XCTAssertFalse(day.dayLabel.isEmpty, "Day label must not be empty")
+        }
+    }
+
+    func test_generatePlan_weekdayIndicesAreValid() async throws {
+        let profile = try makeProfile()
+        let plan = try await sut.generatePlan(profile: profile)
+
+        for day in plan.days {
+            XCTAssertTrue(
+                (1...7).contains(day.weekdayIndex),
+                "weekdayIndex \(day.weekdayIndex) for '\(day.dayLabel)' must be in range 1-7"
+            )
+        }
+    }
+
+    func test_generatePlan_daysHaveDistinctWeekdayIndices() async throws {
+        let profile = try makeProfile()
+        let plan = try await sut.generatePlan(profile: profile)
+
+        let indices = plan.days.map { $0.weekdayIndex }
+        let uniqueIndices = Set(indices)
+        XCTAssertEqual(indices.count, uniqueIndices.count, "All workout days must fall on different weekdays")
+    }
+
+    // MARK: - PlannedExercise structure
+
+    func test_generatePlan_exercisesHavePositiveSets() async throws {
+        let profile = try makeProfile()
+        let plan = try await sut.generatePlan(profile: profile)
+
+        for day in plan.days {
+            for exercise in day.plannedExercises {
+                XCTAssertGreaterThan(exercise.targetSets, 0, "targetSets must be positive")
+            }
+        }
+    }
+
+    func test_generatePlan_exercisesHaveNonEmptyReps() async throws {
+        let profile = try makeProfile()
+        let plan = try await sut.generatePlan(profile: profile)
+
+        for day in plan.days {
+            for exercise in day.plannedExercises {
+                XCTAssertFalse(exercise.targetReps.isEmpty, "targetReps must not be empty")
+            }
+        }
+    }
+
+    func test_generatePlan_exerciseSortOrderIsSequential() async throws {
+        let profile = try makeProfile()
+        let plan = try await sut.generatePlan(profile: profile)
+
+        for day in plan.days {
+            let sortOrders = day.plannedExercises
+                .sorted { $0.sortOrder < $1.sortOrder }
+                .map { $0.sortOrder }
+
+            for (index, order) in sortOrders.enumerated() {
+                XCTAssertEqual(order, index, "sortOrder must be sequential starting at 0")
+            }
+        }
+    }
+
+    // MARK: - No network call
+
+    func test_generatePlan_doesNotThrow() async throws {
+        // FallbackPlanProvider must never throw — verify for different profiles.
+        let profiles: [UserProfile] = try [
+            makeProfile(goal: .cut, activityLevel: .sedentary),
+            makeProfile(goal: .maintain, activityLevel: .moderatelyActive),
+            makeProfile(goal: .bulk, activityLevel: .extraActive),
+        ]
+
+        for profile in profiles {
+            XCTAssertNoThrow(try await sut.generatePlan(profile: profile))
+        }
+    }
+
+    // MARK: - UserProfile association
+
+    func test_generatePlan_planIsAssociatedWithProfile() async throws {
+        let profile = try makeProfile()
+        let plan = try await sut.generatePlan(profile: profile)
+        XCTAssertTrue(plan.userProfile === profile, "Plan must be associated with the provided UserProfile")
+    }
+}


### PR DESCRIPTION
## Implementation Complete

## Summary

- **`ClaudeAPIClient`** — async/await HTTP client for `POST https://api.anthropic.com/v1/messages`. Constructs a structured prompt from `UserProfile` embedding all four required inputs (goal, experience level, equipment list, days/week), sends the request with proper Anthropic API headers, strips markdown fences from the response, decodes the `WorkoutPlanResponse` JSON, and maps it into a `WorkoutPlan` → `WorkoutDay` → `PlannedExercise` SwiftData entity graph. Throws typed `ClaudeAPIError` on missing API key, network failure, non-200 HTTP status, or decode failure.
- **`FallbackPlanProvider`** — returns a hard-coded 3-day full-body template plan with no network call. Used by `WorkoutPlanViewModel` (task-3) when `ClaudeAPIClient` throws.
- Both conform to the new `WorkoutPlanGenerating` protocol, enabling clean injection and testability.
- **`AppEnvironment`** updated to expose `claudeAPIClient` and `fallbackPlanProvider`, wired automatically from the shared `KeychainService`.
- **`ClaudeAPIClientTests`** — 14 tests covering success path, all error variants, prompt field validation, header inspection, and entity mapping using `MockURLProtocol`.
- **`FallbackPlanProviderTests`** — 11 tests verifying plan is non-empty, structure is valid, no throws under any profile, and `userProfile` association is set.

Closes #35

## Tasks Completed

- [x] Analyze the issue requirements
- [x] Implement the core changes
- [x] Add tests for new functionality
- [x] Update documentation if needed


---
**Issue:** #35 (Closes #35)
**Agent:** `backend-engineer`
**Branch:** `feature/35-ios-fitness-tracker-app-sprint-4-issue-35`