### PR TITLE
feat: implement PRDetector domain logic

### DIFF
--- a/.claude-output.json
+++ b/.claude-output.json
@@ -1,0 +1,15 @@
+{
+  "prTitle": "feat: implement PRDetector domain logic",
+  "prBody": "## Summary\n\n- Adds `PRDetector` as a pure, framework-free domain service in `FitnessTracker/Domain/PRDetector.swift`\n- Introduces `SetRecord` value type (weightKg, reps, computed `volume = weight × reps`) and `PRResult` (isPR, previousBest, newSet)\n- `PRDetector.check(newSet:history:)` returns a PR when the new set's volume strictly exceeds the highest historical volume; empty history is always a PR (first-ever set)\n- 13 `XCTest` unit tests covering all three acceptance criteria: new PR detection, no-PR case, and empty-history edge case\n\nCloses #59",
+  "testsPass": true,
+  "filesChanged": [
+    "FitnessTracker/Domain/PRDetector.swift",
+    "FitnessTrackerTests/PRDetectorTests.swift"
+  ],
+  "docsUpdated": [],
+  "docsReviewed": [
+    "docs/concepts/ios-fitness-tracker-app/LLD.md",
+    "docs/concepts/ios-fitness-tracker-app/tasks.yaml"
+  ],
+  "completedTasks": [1]
+}

--- a/.review-feedback.txt
+++ b/.review-feedback.txt
@@ -1,6 +1,6 @@
 ## Code Review - Changes Requested
 
-The review is complete. The PR is blocked because **no implementation exists** — it's an empty WIP branch with zero code changes. The review JSON has been written to `/workspace/.claude-review.json` with `changes_requested` and `hasBlockingIssues: true`.
+Review complete. The PR has **no code changes** — it's a draft WIP placeholder with 0 additions/deletions. The required `PRDetector.swift` implementation and tests are entirely absent. I've marked it as `changes_requested` with `hasBlockingIssues: true` since there's literally nothing to merge.
 
 **Action Required**: Please address the blocking issues above before merging.
 

--- a/FitnessTracker/Domain/PRDetector.swift
+++ b/FitnessTracker/Domain/PRDetector.swift
@@ -1,0 +1,66 @@
+import Foundation
+
+// MARK: - SetRecord
+
+/// A lightweight, framework-free value representing a single logged exercise set.
+/// Used by `PRDetector` so callers do not need to pass SwiftData model objects.
+struct SetRecord {
+    /// Weight lifted in kilograms.
+    let weightKg: Double
+    /// Number of repetitions performed.
+    let reps: Int
+
+    /// 1RM-equivalent volume used for PR comparison: weight × reps.
+    var volume: Double { weightKg * Double(reps) }
+}
+
+// MARK: - PRResult
+
+/// The outcome of a PR-detection check.
+struct PRResult {
+    /// Whether the evaluated set constitutes a new personal record.
+    let isPR: Bool
+    /// The best historical set prior to the new set, or `nil` when no history exists.
+    let previousBest: SetRecord?
+    /// The new set that was evaluated.
+    let newSet: SetRecord
+}
+
+// MARK: - PRDetector
+
+/// Pure, framework-free domain service that detects personal records for a given
+/// exercise by comparing a new set's 1RM-equivalent volume (weight × reps) against
+/// the historical best.
+///
+/// **PR rule:**
+/// A set is a PR when its `volume` (weightKg × reps) **strictly exceeds** the
+/// highest `volume` seen in `history`.  When `history` is empty (first-ever set
+/// for that exercise) the set is always considered a PR.
+///
+/// Callers convert `LoggedSet` SwiftData objects to `SetRecord` values before
+/// invoking this service, keeping the domain logic decoupled from persistence.
+struct PRDetector {
+
+    // MARK: - Check
+
+    /// Evaluates whether `newSet` sets a new personal record.
+    ///
+    /// - Parameters:
+    ///   - newSet: The set just logged by the user.
+    ///   - history: All previously completed sets for the **same exercise**, in any order.
+    ///     Pass an empty array when this is the athlete's first-ever set for the exercise.
+    /// - Returns: A `PRResult` describing whether a PR was achieved, the previous best
+    ///   (if any), and the evaluated set.
+    static func check(newSet: SetRecord, history: [SetRecord]) -> PRResult {
+        guard !history.isEmpty else {
+            // No history → first set ever for this exercise is always a PR.
+            return PRResult(isPR: true, previousBest: nil, newSet: newSet)
+        }
+
+        // Identify the historical set with the highest volume.
+        let bestHistorical = history.max(by: { $0.volume < $1.volume })!
+
+        let isPR = newSet.volume > bestHistorical.volume
+        return PRResult(isPR: isPR, previousBest: bestHistorical, newSet: newSet)
+    }
+}

--- a/FitnessTrackerTests/PRDetectorTests.swift
+++ b/FitnessTrackerTests/PRDetectorTests.swift
@@ -1,0 +1,160 @@
+import XCTest
+@testable import FitnessTracker
+
+// MARK: - PRDetectorTests
+
+/// Unit tests for `PRDetector`.
+///
+/// Tests cover the three acceptance criteria:
+/// 1. New PR detected when weight × reps exceeds historical best.
+/// 2. No PR returned when the set does not exceed the historical best.
+/// 3. Empty history (first-ever set for an exercise) is always a PR.
+final class PRDetectorTests: XCTestCase {
+
+    // MARK: - Helpers
+
+    /// Convenience factory for `SetRecord`.
+    private func set(weightKg: Double, reps: Int) -> SetRecord {
+        SetRecord(weightKg: weightKg, reps: reps)
+    }
+
+    // MARK: - Empty history (first-ever set)
+
+    func testCheck_emptyHistory_isPR() {
+        let newSet = set(weightKg: 100, reps: 5)
+        let result = PRDetector.check(newSet: newSet, history: [])
+
+        XCTAssertTrue(result.isPR, "First-ever set should always be a PR")
+    }
+
+    func testCheck_emptyHistory_previousBestIsNil() {
+        let newSet = set(weightKg: 80, reps: 8)
+        let result = PRDetector.check(newSet: newSet, history: [])
+
+        XCTAssertNil(result.previousBest, "No previous best exists for empty history")
+    }
+
+    func testCheck_emptyHistory_newSetIsPreserved() {
+        let newSet = set(weightKg: 60, reps: 3)
+        let result = PRDetector.check(newSet: newSet, history: [])
+
+        XCTAssertEqual(result.newSet.weightKg, 60)
+        XCTAssertEqual(result.newSet.reps, 3)
+    }
+
+    // MARK: - PR achieved (volume exceeds history)
+
+    func testCheck_higherVolume_isPR() {
+        // History best: 100 kg × 5 reps = 500 kg
+        // New set:      100 kg × 6 reps = 600 kg → PR
+        let history = [set(weightKg: 100, reps: 5)]
+        let newSet  = set(weightKg: 100, reps: 6)
+        let result  = PRDetector.check(newSet: newSet, history: history)
+
+        XCTAssertTrue(result.isPR)
+    }
+
+    func testCheck_higherWeightSameReps_isPR() {
+        // History best: 80 kg × 5 reps = 400 kg
+        // New set:      90 kg × 5 reps = 450 kg → PR
+        let history = [set(weightKg: 80, reps: 5)]
+        let newSet  = set(weightKg: 90, reps: 5)
+        let result  = PRDetector.check(newSet: newSet, history: history)
+
+        XCTAssertTrue(result.isPR)
+    }
+
+    func testCheck_higherVolumeAmongMultipleHistorySets_isPR() {
+        // Multiple history records; best is 100 × 10 = 1000
+        let history = [
+            set(weightKg: 80,  reps: 10),   // 800
+            set(weightKg: 100, reps: 10),   // 1000  ← best
+            set(weightKg: 90,  reps: 8)     // 720
+        ]
+        let newSet = set(weightKg: 100, reps: 11) // 1100 → PR
+        let result = PRDetector.check(newSet: newSet, history: history)
+
+        XCTAssertTrue(result.isPR)
+        XCTAssertEqual(result.previousBest?.weightKg, 100)
+        XCTAssertEqual(result.previousBest?.reps, 10)
+    }
+
+    func testCheck_previousBestIsPopulatedOnPR() {
+        let history = [set(weightKg: 60, reps: 10)]  // 600
+        let newSet  = set(weightKg: 70, reps: 10)    // 700 → PR
+        let result  = PRDetector.check(newSet: newSet, history: history)
+
+        XCTAssertNotNil(result.previousBest)
+        XCTAssertEqual(result.previousBest?.weightKg, 60)
+        XCTAssertEqual(result.previousBest?.reps, 10)
+    }
+
+    // MARK: - No PR (volume does not exceed history)
+
+    func testCheck_equalVolume_isNotPR() {
+        // Equal volume is not strictly greater → no PR
+        let history = [set(weightKg: 100, reps: 5)]  // 500
+        let newSet  = set(weightKg: 100, reps: 5)    // 500 (equal)
+        let result  = PRDetector.check(newSet: newSet, history: history)
+
+        XCTAssertFalse(result.isPR, "Equal volume must not be flagged as a PR")
+    }
+
+    func testCheck_lowerVolume_isNotPR() {
+        // History best: 100 kg × 10 reps = 1000 kg
+        // New set:       90 kg × 10 reps = 900 kg → not a PR
+        let history = [set(weightKg: 100, reps: 10)]
+        let newSet  = set(weightKg: 90,  reps: 10)
+        let result  = PRDetector.check(newSet: newSet, history: history)
+
+        XCTAssertFalse(result.isPR)
+    }
+
+    func testCheck_lowerRepsHigherWeight_belowHistoricalVolume_isNotPR() {
+        // History: 60 kg × 12 reps = 720
+        // New set: 80 kg × 8  reps = 640 → not a PR
+        let history = [set(weightKg: 60, reps: 12)]
+        let newSet  = set(weightKg: 80, reps: 8)
+        let result  = PRDetector.check(newSet: newSet, history: history)
+
+        XCTAssertFalse(result.isPR)
+    }
+
+    func testCheck_notPR_previousBestIsPopulated() {
+        let history = [set(weightKg: 100, reps: 5)]
+        let newSet  = set(weightKg: 80,  reps: 5)
+        let result  = PRDetector.check(newSet: newSet, history: history)
+
+        XCTAssertFalse(result.isPR)
+        XCTAssertNotNil(result.previousBest)
+        XCTAssertEqual(result.previousBest?.weightKg, 100)
+    }
+
+    // MARK: - previousBest reflects the max-volume historical set
+
+    func testCheck_previousBestIsHighestVolumeNotFirstElement() {
+        // History has three records; detector must pick the true best, not the first.
+        let history = [
+            set(weightKg: 50, reps: 10),   // 500
+            set(weightKg: 80, reps: 10),   // 800  ← true best
+            set(weightKg: 70, reps: 8)     // 560
+        ]
+        let newSet = set(weightKg: 90, reps: 10) // 900 → PR
+        let result = PRDetector.check(newSet: newSet, history: history)
+
+        XCTAssertEqual(result.previousBest?.weightKg, 80)
+        XCTAssertEqual(result.previousBest?.reps, 10)
+    }
+
+    // MARK: - Volume computation
+
+    func testSetRecord_volume_isWeightTimesReps() {
+        let record = SetRecord(weightKg: 75, reps: 8)
+        XCTAssertEqual(record.volume, 600, accuracy: 0.001)
+    }
+
+    func testSetRecord_zeroReps_volumeIsZero() {
+        let record = SetRecord(weightKg: 100, reps: 0)
+        XCTAssertEqual(record.volume, 0, accuracy: 0.001)
+    }
+}


### PR DESCRIPTION
## Implementation Complete

## Summary

- Adds `PRDetector` as a pure, framework-free domain service in `FitnessTracker/Domain/PRDetector.swift`
- Introduces `SetRecord` value type (weightKg, reps, computed `volume = weight × reps`) and `PRResult` (isPR, previousBest, newSet)
- `PRDetector.check(newSet:history:)` returns a PR when the new set's volume strictly exceeds the highest historical volume; empty history is always a PR (first-ever set)
- 13 `XCTest` unit tests covering all three acceptance criteria: new PR detection, no-PR case, and empty-history edge case

Closes #59

## Tasks Completed

- [x] Implementation complete


---
**Issue:** #59 (Closes #59)
**Agent:** `backend-engineer`
**Branch:** `feature/59-ios-fitness-tracker-app-sprint-5-issue-59`